### PR TITLE
get_output_info is refactored

### DIFF
--- a/nncf/onnx/statistics/aggregator.py
+++ b/nncf/onnx/statistics/aggregator.py
@@ -25,6 +25,7 @@ from nncf.onnx.graph.node_utils import get_input_edge
 from nncf.onnx.graph.node_utils import get_input_edges_mapping
 from nncf.onnx.graph.onnx_helper import get_name_to_node_map
 from nncf.onnx.graph.transformations.commands import ONNXOutputInsertionCommand
+from nncf.onnx.statistics.collectors import ONNXOutputMetadata
 from nncf.onnx.tensor import ONNXNNCFTensor
 
 
@@ -57,11 +58,8 @@ class ONNXStatisticsAggregator(StatisticsAggregator):
             else:
                 RuntimeError(f"Unsupported target point type for statistic aggregator: {target_point.type}")
 
-            input_info = []
-            for reducer in tensor_collector.reducers:
-                input_info.append((hash(reducer), [edge_name]))
-
-            target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, input_info)
+            target_inputs_metadata = tensor_collector.get_target_inputs_metadata(ONNXOutputMetadata(edge_name))
+            target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, target_inputs_metadata)
             tensor_collector.register_inputs(target_inputs)
 
     def _get_transformation_layout_extra_outputs(

--- a/nncf/onnx/statistics/collectors.py
+++ b/nncf/onnx/statistics/collectors.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from typing import Deque, List, Optional, Tuple, Union
 
 import numpy as np
@@ -26,6 +27,7 @@ from nncf.experimental.common.tensor_statistics.collectors import MeanReducer
 from nncf.experimental.common.tensor_statistics.collectors import MinReducer
 from nncf.experimental.common.tensor_statistics.collectors import NoopAggregator
 from nncf.experimental.common.tensor_statistics.collectors import NoopReducer
+from nncf.experimental.common.tensor_statistics.collectors import OutputMetadata
 from nncf.experimental.common.tensor_statistics.collectors import QuantileReducer
 from nncf.experimental.common.tensor_statistics.collectors import ShapeAggregator
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
@@ -188,15 +190,20 @@ class ONNXNNCFCollectorTensorProcessor(NNCFCollectorTensorProcessor):
         raise NotImplementedError()
 
 
+@dataclass
+class ONNXOutputMetadata(OutputMetadata):
+    edge_name: str
+
+
 class ONNXBasicReducer(TensorReducerBase):
     def _get_processor(self):
         return ONNXNNCFCollectorTensorProcessor
 
     def get_inplace_fn(self):
-        raise RuntimeError("ONNX backend has no support of inplace statistics.")
+        raise RuntimeError("ONNX backend has no support of inplace statistics yet.")
 
-    def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
-        raise NotImplementedError("The method is not implemented.")
+    def get_output_names(self, output_metadata: ONNXOutputMetadata) -> List[str]:
+        return [output_metadata.edge_name]
 
 
 class ONNXNoopReducer(ONNXBasicReducer, NoopReducer):

--- a/nncf/openvino/statistics/aggregator.py
+++ b/nncf/openvino/statistics/aggregator.py
@@ -25,6 +25,7 @@ from nncf.experimental.common.tensor_statistics.collectors import MergedTensorCo
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.openvino.graph.transformations.commands import OVInplaceFnInsertionCommand
 from nncf.openvino.graph.transformations.commands import OVOutputInsertionCommand
+from nncf.openvino.statistics.collectors import OVOutputMetadata
 from nncf.openvino.tensor import OVNNCFTensor
 
 
@@ -50,8 +51,10 @@ class OVStatisticsAggregator(StatisticsAggregator):
             else:
                 RuntimeError(f"Unsupported target point type for statistic aggregator: {target_point.type}")
 
-            input_info = tensor_collector.get_output_info(stat_node_name, port_id)
-            target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, input_info)
+            target_inputs_metadata = tensor_collector.get_target_inputs_metadata(
+                OVOutputMetadata(stat_node_name, port_id)
+            )
+            target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, target_inputs_metadata)
             tensor_collector.register_inputs(target_inputs)
 
     def _get_transformation_layout_extra_outputs(

--- a/tests/common/experimental/test_statistic_collector.py
+++ b/tests/common/experimental/test_statistic_collector.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import List, Optional, Type
 
 import numpy as np
@@ -23,6 +24,7 @@ from nncf.common.tensor_statistics.statistics import PercentileTensorStatistic
 from nncf.common.tensor_statistics.statistics import RawTensorStatistic
 from nncf.experimental.common.tensor_statistics.collectors import AggregatorBase
 from nncf.experimental.common.tensor_statistics.collectors import MergedTensorCollector
+from nncf.experimental.common.tensor_statistics.collectors import OutputMetadata
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
 from nncf.experimental.common.tensor_statistics.collectors import TensorReducerBase
 from nncf.experimental.common.tensor_statistics.collectors import TensorType
@@ -55,7 +57,7 @@ class DummyTensorReducer(TensorReducerBase):
     def get_inplace_fn(self):
         return self._inplace_mock
 
-    def get_output_names(self, target_node_name: str, port_id: int) -> str:
+    def get_output_names(self, output_metadata: OutputMetadata) -> str:
         return [self._output_name]
 
     def _get_processor(self):
@@ -138,9 +140,9 @@ def test_duplicated_statistics_are_merged():
     assert len(collector._aggregators) == 4
     assert collector.num_samples == 100
 
-    output_info = collector.get_output_info(None, None)
-    # Check output info
-    assert sorted(output_info) == sorted(
+    target_inputs_metadata = collector.get_target_inputs_metadata(None)
+    # Check target_inputs_metadata
+    assert sorted(target_inputs_metadata) == sorted(
         [(hash(reducer_inplace), ["Dummy_inplace"]), (hash(reducer_a), ["A"]), (hash(reducer), ["Dummy"])]
     )
 
@@ -149,7 +151,7 @@ def test_duplicated_statistics_are_merged():
         "A": NumpyNNCFTensor(np.array(0)),
         "Dummy_inplace": NumpyNNCFTensor(np.array(6)),
     }
-    target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, output_info)
+    target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, target_inputs_metadata)
     collector.register_inputs(target_inputs)
 
     # Check aggregators recieved inputs as expected
@@ -214,10 +216,10 @@ def test_merged_tensor_collector():
     for collector in collectors[:-1]:
         assert collector.aggregators[common_branch_key] is common_aggregator
 
-    output_info = merged_collector.get_output_info(None, None)
+    target_inputs_metadata = merged_collector.get_target_inputs_metadata(None)
     outputs = {"common_input": NumpyNNCFTensor(np.array(0))}
     outputs.update({f"input_{idx + 1}": NumpyNNCFTensor(np.array(idx + 1)) for idx, _ in enumerate(collectors[:-1])})
-    target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, output_info)
+    target_inputs = TensorCollector.get_tensor_collector_inputs(outputs, target_inputs_metadata)
     merged_collector.register_inputs(target_inputs)
 
     # Check statistics are collected in a correct way
@@ -249,6 +251,12 @@ def test_ambiguous_branches():
         collector.register_statistic_branch("B", reducer, aggregator)
 
 
+@dataclass
+class DummyOutputMetadata(OutputMetadata):
+    target_node_name: str
+    port_id: int
+
+
 class DummyMultipleInpOutTensorReducer(DummyTensorReducer):
     NUM_INPUTS = 3
     NUM_OUTPUTS = 2
@@ -256,8 +264,11 @@ class DummyMultipleInpOutTensorReducer(DummyTensorReducer):
     def _reduce_out_of_place(self, x: List[TensorType]):
         return x[: self.NUM_OUTPUTS]
 
-    def get_output_names(self, target_node_name: str, port_id: int) -> str:
-        return [f"{target_node_name}_{port_id}_{self._output_name}_{i}" for i in range(self.NUM_INPUTS)]
+    def get_output_names(self, output_metadata: DummyOutputMetadata) -> List[str]:
+        return [
+            f"{output_metadata.target_node_name}_{output_metadata.port_id}_{self._output_name}_{i}"
+            for i in range(self.NUM_INPUTS)
+        ]
 
 
 def test_multiple_branch_reducer():
@@ -282,10 +293,10 @@ def test_multiple_branch_reducer():
     ]
     inputs = {name: NumpyNNCFTensor(np.array(i)) for i, name in enumerate(ref_output_info[0][1])}
 
-    output_info = collector.get_output_info(target_node_name, 0)
-    assert output_info == ref_output_info
+    target_inputs_metadata = collector.get_target_inputs_metadata(DummyOutputMetadata(target_node_name, 0))
+    assert target_inputs_metadata == ref_output_info
 
-    target_inputs = collector.get_tensor_collector_inputs(inputs, output_info)
+    target_inputs = collector.get_tensor_collector_inputs(inputs, target_inputs_metadata)
     collector.register_inputs(target_inputs)
 
     ref_stats = {"0": NumpyNNCFTensor(np.array(0)), "1": NumpyNNCFTensor(np.array(1))}


### PR DESCRIPTION
### Changes

OutputMetadata is used in `get_target_inputs_metadata` instead of backend-specific node_name and port id
### Reason for changes


